### PR TITLE
Improving the binding to the `Serial` object and fix SoftwareSerial bug

### DIFF
--- a/examples/HardwareSerial/platformio.ini
+++ b/examples/HardwareSerial/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 src_dir = ./
+lib_dir = ../../../
 
 [env]
 framework = arduino

--- a/examples/OLED_64x48/platformio.ini
+++ b/examples/OLED_64x48/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 src_dir = ./
+lib_dir = ../../../
 
 [env]
 framework = arduino
@@ -17,7 +18,6 @@ lib_deps = ESP8266_SSD1306
 
 [env:d1_mini]
 platform = espressif8266
-lib_deps = ${env.lib_deps}, EspSoftwareSerial@>=6.7.1
 board = d1_mini
 
 [env:mhetesp32minikit]

--- a/examples/SoftwareSerial/.gitignore
+++ b/examples/SoftwareSerial/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .pio
 .pioenvs
 .piolibdeps

--- a/examples/SoftwareSerial/SoftwareSerial.ino
+++ b/examples/SoftwareSerial/SoftwareSerial.ino
@@ -4,10 +4,18 @@
 #include <SoftwareSerial.h>
 #endif
 #include <PMserial.h> // Arduino library for PM sensors with serial interface
+
 #if !defined(PMS_RX) && !defined(PMS_TX)
-const uint8_t PMS_RX = 10, PMS_TX = 11;
+constexpr auto PMS_RX = 10;
+constexpr auto PMS_TX = 11;
 #endif
+
+#ifndef ESP32
+SoftwareSerial SoftSerial1(PMS_RX, PMS_TX);
+SerialPM pms(PMS5003, SoftSerial1); // PMSx003, RX, TX
+#else
 SerialPM pms(PMS5003, PMS_RX, PMS_TX); // PMSx003, RX, TX
+#endif
 
 void setup()
 {
@@ -19,6 +27,7 @@ void setup()
   Serial.println(PMS_RX);
   Serial.print(F("  TX:"));
   Serial.println(PMS_TX);
+
   pms.init();
 }
 

--- a/examples/SoftwareSerial/SoftwareSerial.ino
+++ b/examples/SoftwareSerial/SoftwareSerial.ino
@@ -11,8 +11,11 @@ constexpr auto PMS_TX = 11;
 #endif
 
 #ifndef ESP32
-SoftwareSerial SoftSerial1(PMS_RX, PMS_TX);
-SerialPM pms(PMS5003, SoftSerial1); // PMSx003, RX, TX
+SerialPM pms(PMS5003, PMS_RX, PMS_TX); // PMSx003, RX, TX
+
+// Alternative:
+//SoftwareSerial SoftSerial1(PMS_RX, PMS_TX);
+//SerialPM pms(PMS5003, SoftSerial1);
 #else
 SerialPM pms(PMS5003, PMS_RX, PMS_TX); // PMSx003, RX, TX
 #endif

--- a/examples/SoftwareSerial/platformio.ini
+++ b/examples/SoftwareSerial/platformio.ini
@@ -10,36 +10,31 @@
 
 [platformio]
 src_dir = ./
+lib_dir = ../../../
+default_envs = 
 
 [env]
 framework = arduino
 
 [env:uno]
-; ATmega328, 5V/16MHz
 platform = atmelavr
 board = uno
 
 [env:mini168_3V3]
-; ATmega168, 3.3V/8MHz
 platform = atmelavr
 board = pro8MHzatmega168
 
 [env:mini328_3V3]
-; ATmega328, 3.3V/8MHz
 platform = atmelavr
 board = pro8MHzatmega328
 
 [env:esp01]
-; ESP8266, 512kB flash
 platform = espressif8266
-lib_deps = EspSoftwareSerial@>=6.7.1
 board = esp01
 build_flags = -D PMS_RX=2 -D PMS_TX=0
 
 [env:d1_mini]
-; ESP8266, 4096kB flash
 platform = espressif8266
-lib_deps = EspSoftwareSerial@>=6.7.1
 board = d1_mini
 build_flags = -D PMS_RX=D7 -D PMS_TX=D6
 
@@ -47,3 +42,7 @@ build_flags = -D PMS_RX=D7 -D PMS_TX=D6
 platform = espressif32
 board = mhetesp32minikit
 build_flags = -D PMS_RX=23 -D PMS_TX=19
+
+[env:diecimilaatmega328]
+board = diecimilaatmega328
+platform = atmelavr

--- a/examples/debug/platformio.ini
+++ b/examples/debug/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 src_dir = ./
+lib_dir = ../../../
 
 [env]
 framework = arduino
@@ -48,13 +49,11 @@ board = maple_mini_b20
 [env:esp01]
 ; esp8266 (512Kb)
 platform = espressif8266
-lib_deps = EspSoftwareSerial@>=6.7.1
 board = esp01
 
 [env:aqmon]
 ; esp8266 (1Mb)
 platform = espressif8266
-lib_deps = EspSoftwareSerial@>=6.7.1
 board = esp01_1m
 upload_resetmethod = nodemcu
 build_flags = -D USE_HWSERIAL
@@ -62,7 +61,6 @@ build_flags = -D USE_HWSERIAL
 [env:d1_mini]
 ; esp8266 (4Mb)
 platform = espressif8266
-lib_deps = EspSoftwareSerial@>=6.7.1
 board = d1_mini
 build_flags = -D PMS_RX=D7 -D PMS_TX=D6
 

--- a/src/PMserial.cpp
+++ b/src/PMserial.cpp
@@ -107,6 +107,9 @@ void SerialPM::wake() {
 
 SerialPM::STATUS SerialPM::trigRead()
 {
+  if (hwSerial == false)
+    static_cast<SoftwareSerial *>(uart)->listen(); // when you want to listen on a port, explicitly select it. (https://www.arduino.cc/en/Tutorial/LibraryExamples/TwoPortReceive)
+
   while (uart->available())
   {
     uart->read(); // empty the RX buffer

--- a/src/PMserial.cpp
+++ b/src/PMserial.cpp
@@ -66,25 +66,22 @@ const uint8_t
 void SerialPM::init()
 {
 #ifdef ESP32
-  if (hwSerial && rx && tx)
-  {
+  if ((hwSerial == serModeHardware) && rx && tx)
     static_cast<HardwareSerial *>(uart)->begin(9600, SERIAL_8N1, rx, tx);
-  }
-  else if (hwSerial)
 #else
-  if (hwSerial)
-#endif
-  {
+
 #ifdef HAS_HW_SERIAL
+  if (hwSerial == serModeHardware)
     static_cast<HardwareSerial *>(uart)->begin(9600, SERIAL_8N1);
 #endif
-  }
-  else
-  {
+
+#endif // ESP32
+
 #ifdef HAS_SW_SERIAL
+  if (hwSerial == serModeSoftware)
     static_cast<SoftwareSerial *>(uart)->begin(9600);
 #endif
-  }
+
   uart->write(cfg, msgLen); // set passive mode
   uart->flush();
   delay(max_wait_ms * 2);
@@ -107,8 +104,10 @@ void SerialPM::wake() {
 
 SerialPM::STATUS SerialPM::trigRead()
 {
-  if (hwSerial == false)
+  #ifdef HAS_SW_SERIAL
+  if (hwSerial == serModeSoftware)
     static_cast<SoftwareSerial *>(uart)->listen(); // when you want to listen on a port, explicitly select it. (https://www.arduino.cc/en/Tutorial/LibraryExamples/TwoPortReceive)
+  #endif
 
   while (uart->available())
   {

--- a/src/PMserial.h
+++ b/src/PMserial.h
@@ -78,19 +78,34 @@ public:
     };
   };
 
+  // manual mode - you need configure SerialPort manual and link to this object (function "setSerialPort")
+  SerialPM(PMS sensor) : pms(sensor)
+  {
+    uart = nullptr;
+    hwSerial = serModeManual;
+  }
+
 #ifdef HAS_HW_SERIAL
   SerialPM(PMS sensor, HardwareSerial &serial) : pms(sensor)
   {
     uart = &serial;
-    hwSerial = true;
+    hwSerial = serModeHardware;
   }
 #endif
 
 #ifdef HAS_SW_SERIAL
+  SerialPM(PMS sensor, uint8_t rx, uint8_t tx) : pms(sensor)
+  {
+    static SoftwareSerial serial(rx, tx);
+    uart = &serial;
+    hwSerial = serModeSoftware;
+  }
+
   SerialPM(PMS sensor, Stream &serial) : pms(sensor)
   {
     uart = &serial;
-    hwSerial = false;
+    //TODO: WIP!!!
+    hwSerial = serModeManual;
   }
 #elif defined(ESP32)
   SerialPM(PMS sensor, uint8_t rx, uint8_t tx) : pms(sensor), rx(rx), tx(tx)
@@ -101,6 +116,7 @@ public:
 #endif
 
   void init();
+
 #define PMS_ERROR_TIMEOUT "Sensor read timeout"
 #define PMS_ERROR_PMS_TYPE "Wrong PMSx003 sensor type"
 #define PMS_ERROR_MSG_UNKNOWN "Unknown message protocol"
@@ -109,6 +125,7 @@ public:
 #define PMS_ERROR_MSG_START "Wrong message start"
 #define PMS_ERROR_MSG_LENGTH "Message too long"
 #define PMS_ERROR_MSG_CKSUM "Wrong message checksum"
+
   enum STATUS
   {
     OK,
@@ -121,6 +138,7 @@ public:
     ERROR_MSG_LENGTH,
     ERROR_MSG_CKSUM
   };
+
   STATUS status;
   STATUS read(bool tsi_mode = false, bool truncated_num = false);
   operator bool() { return status == OK; }
@@ -130,6 +148,8 @@ public:
   inline bool has_number_concentration() { return (status == OK) && (pms != PMS3003); }
   inline bool has_temperature_humidity() { return (status == OK) && ((pms == PMS5003T) || (pms == PMS5003ST)); }
   inline bool has_formaldehyde() { return (status == OK) && ((pms == PMS5003S) || (pms == PMS5003ST)); }
+  inline Stream * getSerialPort() { return uart; }
+  inline void setSerialPort(Stream * serial) { uart = serial; hwSerial = serModeManual; }
     
   // adding offsets works well in normal range
   // might introduce under- or overflow at the ends of the sensor range
@@ -158,7 +178,7 @@ public:
 protected:
   Stream *uart;  // hardware/software serial
   PMS pms;       // sensor type/message protocol
-  bool hwSerial; // Is uart hardware serial? (or software serial)
+  enum {serModeHardware, serModeSoftware, serModeManual} hwSerial; // Is uart hardware serial? (or software serial)
 #ifdef ESP32
   uint8_t rx, tx; // Serial1 pins on ESP32
 #endif

--- a/src/PMserial.h
+++ b/src/PMserial.h
@@ -77,6 +77,7 @@ public:
       float temp, rhum, hcho;
     };
   };
+
 #ifdef HAS_HW_SERIAL
   SerialPM(PMS sensor, HardwareSerial &serial) : pms(sensor)
   {
@@ -84,10 +85,10 @@ public:
     hwSerial = true;
   }
 #endif
+
 #ifdef HAS_SW_SERIAL
-  SerialPM(PMS sensor, uint8_t rx, uint8_t tx) : pms(sensor)
+  SerialPM(PMS sensor, Stream &serial) : pms(sensor)
   {
-    SoftwareSerial serial(rx, tx);
     uart = &serial;
     hwSerial = false;
   }
@@ -98,6 +99,7 @@ public:
     hwSerial = true;
   }
 #endif
+
   void init();
 #define PMS_ERROR_TIMEOUT "Sensor read timeout"
 #define PMS_ERROR_PMS_TYPE "Wrong PMSx003 sensor type"

--- a/src/PMserial.h
+++ b/src/PMserial.h
@@ -111,7 +111,7 @@ public:
   SerialPM(PMS sensor, uint8_t rx, uint8_t tx) : pms(sensor), rx(rx), tx(tx)
   {
     uart = &Serial1;
-    hwSerial = true;
+    hwSerial = serModeHardware;
   }
 #endif
 


### PR DESCRIPTION
Consider the following situations:
1. We use another MCU (not known to this library) where the set of parameters for `Serial.init(...)` is different (this situation _already_ happened with ESP32).
2. We use our own implementation of `Serial` inherited from `Stream` (such as [AltSoftSerial](https://github.com/PaulStoffregen/AltSoftSerial/blob/master/AltSoftSerial.h)).
3. Pin numbers in Serial can change on the fly (cofigure via web interface).
4. We have a dust sensor and another sensor (of another type) connected to the same `SoftwareSerial`, but responding to a different query format. This configuration is valid, and saving pins - is a common phenomenon. (similar to the situation in #5)
5. We have 16 sensors that need to be polled. For example these are compressed air lines in industry.

In the current implementation of the library it is problematic to solve these problems (without modifying the library code).
So I decided to expand PR and add more general mechanisms. 

In normal projects, the problem of creating objects is solved through the "factory" pattern, but for MK this is superfluous.

It will take some more time to develop (more examples need to be written) and hopefully everyone will like the result.

----


Russian:
Рассмотрим следующие ситуации:
1. Мы используем другой МК (не известный этой библиотеке), в котором набор параметров для `Serial.init(...)` отличается (такая ситуация _уже_ произошла с ESP32).
2. Мы используем свою собственную реализацию `Serial` унаследованную от `Stream` (например [AltSoftSerial](https://github.com/PaulStoffregen/AltSoftSerial/blob/master/AltSoftSerial.h))..
3. Номера пин у SoftwareSerial изменяются на лету (кофигурация через web-интерфейс).
4. У нас датчик пыли и еще один датчик (другого типа) подключенный к этому же `SoftwareSerial`, но отвечающий на другой формат запроса. Такая конфигурация валидна, и экономия пинов это обычное явление. (похоже на ситуацию в #5)
5. У нас 16 датчиков которые нужно опрашивать. Например это линии сжатого воздуха в промышленности.

В текущей реализации библиотеки решить эти проблемы (без внесения изменений в код библиотеки) проблематично.
Поэтому я решил расширить PR и добавить более общие механизмы. 

В обычных проектах проблему создания объектов решают через патерн "фабрика", но для МК это излишне.

Разработка займет еще некоторое время (нужно написать дополнительные примеры) и надеюсь результат понравится всем.


Changes
=================

Core:
---------
SoftwareSerial bug - https://github.com/avaldebe/PMserial/issues/19
Improving the binding to the `Serial` object 