### PR TITLE
add NO_SW_SERIAL_REQUIRED define for software serial compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ set_temp_offset(-0.6);
 set_rhum_offset(2);
 ```
 
+## SoftwareSerial Compatibility
+
+Some libraries (e.g [Arduino-SDI-12](https://github.com/EnviroDIY/Arduino-SDI-12)) conflict with SoftwareSerial library, which is loaded by default for
+some boards. In order to disable SoftwareSerial compatibility, define `NO_SW_SERIAL_REQUIRED` before
+including the library. For example:
+
+```c++
+#define NO_SW_SERIAL_REQUIRED
+#include <PMSerial.h>
+```
+
 ## Contribute
 
 If you have read this far, this is the library for your project

--- a/src/PMserial.h
+++ b/src/PMserial.h
@@ -16,9 +16,13 @@
 #include <HardwareSerial.h>
 #endif
 
+
+
 #if defined(__AVR__) || defined(ESP8266)
+#if defined(SW_REQUIRED)
 #define HAS_SW_SERIAL
 #include <SoftwareSerial.h>
+#endif
 #endif
 
 #if defined(HAS_HWSERIAL1) || defined(BOARD_HAVE_USART1)

--- a/src/PMserial.h
+++ b/src/PMserial.h
@@ -16,13 +16,9 @@
 #include <HardwareSerial.h>
 #endif
 
-
-
-#if defined(__AVR__) || defined(ESP8266)
-#if defined(SW_REQUIRED)
+#if (defined(__AVR__) || defined(ESP8266)) && !defined(NO_SW_SERIAL_REQUIRED)
 #define HAS_SW_SERIAL
 #include <SoftwareSerial.h>
-#endif
 #endif
 
 #if defined(HAS_HWSERIAL1) || defined(BOARD_HAVE_USART1)


### PR DESCRIPTION
I was having a problem with using this library alongside those that use software serial. If I deliberately wanted to avoid using Software serial in order to avoid clashes with other libraries like the [Arduino-SDI-12](https://github.com/EnviroDIY/Arduino-SDI-12), but needed this, I couldn't previously. This was my solution which worked. 

It's 5months old though, I forgot to offer it earlier. But it's probably still relevant given that I see no new commits of recent.