### PR TITLE
Fix missing `intelhex` in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade platformio
+        pip install --upgrade platformio intelhex
     - name: Run PlatformIO
       run: pio ci -l ./ -c "$PLATFORMIO_CI_SRC/platformio.ini"
       env:


### PR DESCRIPTION
I'm sorry that the last PR didn't fix the CI. I forgot to add the `intelhex` python package, and I didn't check the CI on my fork before sending the PR.